### PR TITLE
Correct the library name instruction

### DIFF
--- a/src/main/java/jpassport/PassportFactory.java
+++ b/src/main/java/jpassport/PassportFactory.java
@@ -38,7 +38,7 @@ public class PassportFactory
      * Call this method to generate the library linkage.
      *
      * @param libraryName The library name (the file name of the shared library without extension on all platforms,
-     *                    without lib prefix on Linux and Mac, or the full name of the shared library).
+     *                    without lib prefix on Linux and Mac).
      * @param interfaceClass The class to wrap.
      * @param <T>
      * @return A class linked to call into a DLL or SO using the Foreign Linker.

--- a/src/main/java/jpassport/PassportFactory.java
+++ b/src/main/java/jpassport/PassportFactory.java
@@ -37,7 +37,8 @@ public class PassportFactory
     /**
      * Call this method to generate the library linkage.
      *
-     * @param libraryName The name of the dll or SO file (no extension).
+     * @param libraryName The library name (the file name of the shared library without extension on all platforms,
+     *                    without lib prefix on Linux and Mac, or the full name of the shared library).
      * @param interfaceClass The class to wrap.
      * @param <T>
      * @return A class linked to call into a DLL or SO using the Foreign Linker.


### PR DESCRIPTION
The library name on Linux and Mac does not include the "lib" prefix. For example, "libpng.so" is loaded with name "png".